### PR TITLE
Migrate to dockerhub image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM zenato/puppeteer
-
-USER root
-WORKDIR /
-RUN yarn add mermaid.cli
+FROM neenjaw/mermaid:base
 
 WORKDIR /mmdc
 COPY . /mmdc


### PR DESCRIPTION
Github actions does not cache docker build layers, so if the image already contains the mermaid compiler, it speeds up the execution since it doesn't have to be built again.

The action is now built on a new docker image which just includes the previous call to yarn to add the mermaid library.