### PR TITLE
Allow for custom Markdown suffixes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ function main {
         output_file="$(dasherize_name ${in_file_basename}).png"
         c_mermaid "${in_file}" "${output_path}/${output_file}"
 
-      elif [[ "${in_file_type}" == "md" ]]; then
+      elif is_path_markdown ${in_file_basename} "${MD_SUFFIXES-.md}"; then
 
         output_path="${outpath}"
         c_md_mermaid "${in_file}" "${output_path}"
@@ -54,6 +54,21 @@ function main {
       fi
     fi
   done
+}
+
+function is_path_markdown {
+
+  path="${1}"
+  suffixes="${2}"
+
+  for suffix in ${suffixes}; do
+    if [[ "${path}" == *${suffix} ]]; then
+      return 1
+    fi
+  done
+
+  return 0
+
 }
 
 # $1 - the file to compile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,6 +56,7 @@ function main {
   done
 }
 
+
 function is_path_markdown {
 
   path="${1}"
@@ -68,7 +69,6 @@ function is_path_markdown {
   done
 
   return 0
-
 }
 
 # $1 - the file to compile
@@ -168,6 +168,17 @@ function die {
   exit 1
 }
 
+function validate_md_suffixes {
+
+  for suffix in ${MD_SUFFIXES-}; do
+    if [[ "${suffix}" =~ ^\. ]]; then
+      continue
+    fi
+
+    die "Starting with . character is currently enforced for MD_SUFFIXES. Suffix ${suffix} is missing dot. Valid value is: .${suffix}."
+  done
+}
+
 # Check for all required dependencies
 deps=(node awk realpath basename dirname)
 for dep in "${deps[@]}"; do
@@ -178,6 +189,8 @@ done
 if [[ -z "${ENTRYPOINT_PATH}" ]]; then
   die "'ENTRYPOINT_PATH' is not set, set to location of entrypoint.sh"
 fi
+
+validate_md_suffixes
 
 # Check for required files
 insert_markdown_awk="${ENTRYPOINT_PATH}/insert-markdown.awk"


### PR DESCRIPTION
By specifying MD_SUFFIXES you can customize which suffixes will per
processed as Markdown.