### PR TITLE
Explicitly add `.resources` directory when commiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
+        git add .resources
         git commit -m "Add changes" -a
 
     - name: Push changes


### PR DESCRIPTION
This will allow it to work for new markdown documents and graphs.