### PR TITLE
Support for OUTPUT_FILE_TYPE override for supported Mermaid filetypes, png (default), svg and pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
           echo ${{ steps.getfile.outputs.files }}
 
       - name: compile mermaid
-        uses: neenjaw/compile-mermaid-markdown-action@0.3.0
+        uses: neenjaw/compile-mermaid-markdown-action@0.3.1
         with:
           files: ${{ steps.getfile.outputs.files }}
           output: 'output'
@@ -116,6 +116,7 @@ jobs:
         env:
           HIDE_CODEBLOCKS: 1
           ABSOLUTE_IMAGE_LINKS: 1
+          RENDER_SVG: 1
 
       - name: show changes
         run: |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Looking for suggestions/help in improving this action. If there is a feature you
 ## How to use
 
 The idea is that this action is to be used within a workflow, not as a standalone action at this time.
+OUTPUT_FILE_TYPE can be used to define the output file type, if you don't specify it it will default to png. You can override it to svg or pdf.
 
 ### Sample workflow with automated PR
 
@@ -55,6 +56,7 @@ jobs:
         env:
           HIDE_CODEBLOCKS: 1
           ABSOLUTE_IMAGE_LINKS: 1
+          OUTPUT_FILE_TYPE: "svg"
 
       - name: show changes
         run: |
@@ -109,14 +111,14 @@ jobs:
           echo ${{ steps.getfile.outputs.files }}
 
       - name: compile mermaid
-        uses: neenjaw/compile-mermaid-markdown-action@0.3.0
+        uses: neenjaw/compile-mermaid-markdown-action@0.3.1
         with:
           files: ${{ steps.getfile.outputs.files }}
           output: '.resources'
         env:
           HIDE_CODEBLOCKS: 1
           ABSOLUTE_IMAGE_LINKS: 1
-          RENDER_SVG: 1
+          OUTPUT_FILE_TYPE: "svg"
 
       - name: show changes
         run: |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@
 # For *.md files:
 #   1) finds all of the mermaid markup in the file
 #   2) creates intermediate files in the output directory *.md.<n>.mermaid where n represents the nth block found
-#   3) compile the mermaid to the directory *.md.<n>.mermaid.png
+#   3) compile the mermaid to the directory *.md.<n>.mermaid.png or .svg
 #   4) place a reference to the compiled image in the markdown
 
 set -euo pipefail
@@ -35,16 +35,22 @@ function main {
       in_file_basename=$(basename "${in_file}")
       in_file_type="${in_file_basename##*.}"
 
+      if [[ -z "${RENDER_SVG}" ]]; then
+        out_file_type = "png"
+      else
+        out_file_type = "svg"
+      fi
+
       if [[ "${in_file_type}" == "mermaid" || "${in_file_type}" == "mmd" ]]; then
 
         output_path="${in_file_dirname}"
-        output_file="$(dasherize_name ${in_file_basename}).png"
+        output_file="$(dasherize_name ${in_file_basename}).${out_file_type}"
         c_mermaid "${in_file}" "${output_path}/${output_file}"
 
       elif is_path_markdown "${in_file_basename}" "${MD_SUFFIXES-.md}"; then
 
         output_path="${outpath}"
-        c_md_mermaid "${in_file}" "${output_path}"
+        c_md_mermaid "${in_file}" "${output_path}" "${out_file_type}"
 
       else
 
@@ -85,6 +91,7 @@ function c_md_mermaid {
   printf "Parsing mermaid codeblocks from %s\n" "${1}"
 
   output_path="${2}"
+  output_file_type="${3}"
 
   input_dir=$(dirname "${1}")
   dasherized=$(dasherize_name "${1}")
@@ -117,11 +124,11 @@ function c_md_mermaid {
     rm "${all_file}x"
 
     # Compile mermaid block"
-    c_mermaid "${block_file}-${block_count}" "${output_path}/${dasherized}-${block_count}.png"
+    c_mermaid "${block_file}-${block_count}" "${output_path}/${dasherized}-${block_count}.${output_file_type}"
 
     # Compute relative path from the markdown to the tmp_dir
-    image_relative_path=$(realpath --relative-to="${input_dir}" "${output_path}/${dasherized}-${block_count}.png")
-    image_absolute_path="/${output_path}/${dasherized}-${block_count}.png"
+    image_relative_path=$(realpath --relative-to="${input_dir}" "${output_path}/${dasherized}-${block_count}.${output_file_type}")
+    image_absolute_path="/${output_path}/${dasherized}-${block_count}.${output_file_type}"
 
     if [[ -z "${ABSOLUTE_IMAGE_LINKS}" ]]; then
       image_path="${image_relative_path}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,12 +8,12 @@
 # Usage:
 #   > entrypoint.sh <output path> [<file1> [<file2> ...]]
 
-# For *.mermaid or *.mmd files, it is compiled and a *.mermaid.png is created at the location
+# For *.mermaid or *.mmd files, it is compiled and a *.mermaid.${output_file_type} is created at the location
 
 # For *.md files:
 #   1) finds all of the mermaid markup in the file
 #   2) creates intermediate files in the output directory *.md.<n>.mermaid where n represents the nth block found
-#   3) compile the mermaid to the directory *.md.<n>.mermaid.png
+#   3) compile the mermaid to the directory *.md.<n>.mermaid.${output_file_type}
 #   4) place a reference to the compiled image in the markdown
 
 set -euo pipefail

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,9 +36,9 @@ function main {
       in_file_type="${in_file_basename##*.}"
 
       if [[ -z "${RENDER_SVG}" ]]; then
-        out_file_type = "png"
+        out_file_type="png"
       else
-        out_file_type = "svg"
+        out_file_type="svg"
       fi
 
       if [[ "${in_file_type}" == "mermaid" || "${in_file_type}" == "mmd" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@
 # For *.md files:
 #   1) finds all of the mermaid markup in the file
 #   2) creates intermediate files in the output directory *.md.<n>.mermaid where n represents the nth block found
-#   3) compile the mermaid to the directory *.md.<n>.mermaid.png or .svg
+#   3) compile the mermaid to the directory *.md.<n>.mermaid.png
 #   4) place a reference to the compiled image in the markdown
 
 set -euo pipefail
@@ -24,6 +24,8 @@ function main {
   outpath="${1}"
   mkdir -p "${outpath}"
   printf "Got output path: %s\n" "${outpath}"
+  output_file_type="${OUTPUT_FILE_TYPE:-png}"
+  printf "Filetype: %s\n" "${output_file_type}"
 
   shift $(( OPTIND - 1 ))
 
@@ -35,22 +37,16 @@ function main {
       in_file_basename=$(basename "${in_file}")
       in_file_type="${in_file_basename##*.}"
 
-      if [[ -z "${RENDER_SVG}" ]]; then
-        out_file_type="png"
-      else
-        out_file_type="svg"
-      fi
-
       if [[ "${in_file_type}" == "mermaid" || "${in_file_type}" == "mmd" ]]; then
 
         output_path="${in_file_dirname}"
-        output_file="$(dasherize_name ${in_file_basename}).${out_file_type}"
+        output_file="$(dasherize_name ${in_file_basename}).png"
         c_mermaid "${in_file}" "${output_path}/${output_file}"
 
       elif is_path_markdown "${in_file_basename}" "${MD_SUFFIXES-.md}"; then
 
         output_path="${outpath}"
-        c_md_mermaid "${in_file}" "${output_path}" "${out_file_type}"
+        c_md_mermaid "${in_file}" "${output_path}"
 
       else
 
@@ -91,7 +87,6 @@ function c_md_mermaid {
   printf "Parsing mermaid codeblocks from %s\n" "${1}"
 
   output_path="${2}"
-  output_file_type="${3}"
 
   input_dir=$(dirname "${1}")
   dasherized=$(dasherize_name "${1}")
@@ -124,11 +119,11 @@ function c_md_mermaid {
     rm "${all_file}x"
 
     # Compile mermaid block"
-    c_mermaid "${block_file}-${block_count}" "${output_path}/${dasherized}-${block_count}.${output_file_type}"
+    c_mermaid "${block_file}-${block_count}" "${output_path}/${dasherized}-${block_count}.png"
 
     # Compute relative path from the markdown to the tmp_dir
-    image_relative_path=$(realpath --relative-to="${input_dir}" "${output_path}/${dasherized}-${block_count}.${output_file_type}")
-    image_absolute_path="/${output_path}/${dasherized}-${block_count}.${output_file_type}"
+    image_relative_path=$(realpath --relative-to="${input_dir}" "${output_path}/${dasherized}-${block_count}.png")
+    image_absolute_path="/${output_path}/${dasherized}-${block_count}.png"
 
     if [[ -z "${ABSOLUTE_IMAGE_LINKS}" ]]; then
       image_path="${image_relative_path}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ function main {
       if [[ "${in_file_type}" == "mermaid" || "${in_file_type}" == "mmd" ]]; then
 
         output_path="${in_file_dirname}"
-        output_file="$(dasherize_name ${in_file_basename}).png"
+        output_file="$(dasherize_name ${in_file_basename}).${output_file_type}"
         c_mermaid "${in_file}" "${output_path}/${output_file}"
 
       elif is_path_markdown "${in_file_basename}" "${MD_SUFFIXES-.md}"; then
@@ -119,11 +119,11 @@ function c_md_mermaid {
     rm "${all_file}x"
 
     # Compile mermaid block"
-    c_mermaid "${block_file}-${block_count}" "${output_path}/${dasherized}-${block_count}.png"
+    c_mermaid "${block_file}-${block_count}" "${output_path}/${dasherized}-${block_count}.${output_file_type}"
 
     # Compute relative path from the markdown to the tmp_dir
-    image_relative_path=$(realpath --relative-to="${input_dir}" "${output_path}/${dasherized}-${block_count}.png")
-    image_absolute_path="/${output_path}/${dasherized}-${block_count}.png"
+    image_relative_path=$(realpath --relative-to="${input_dir}" "${output_path}/${dasherized}-${block_count}.${output_file_type}")
+    image_absolute_path="/${output_path}/${dasherized}-${block_count}.${output_file_type}"
 
     if [[ -z "${ABSOLUTE_IMAGE_LINKS}" ]]; then
       image_path="${image_relative_path}"


### PR DESCRIPTION
I've updated entrypoint.sh to accept OUTPUT_FILE_TYPE to override the default png with other strings. It doesn't check for the string type, it falls back on Mermaid cli to error out on invalid filetypes.

I've updated the readme.md too in prep for release 0.3.1. 

Testing has been done manually https://github.com/disambiguationuk/MermaidTest/