### PR TITLE
Make sure all files in argument are taken into account

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ function main {
 
   shift $(( OPTIND - 1 ))
 
-  for in_file in "$@"; do
+  for in_file in $@; do
     if [[ -f "${in_file}" ]]; then
       printf "Attempting compile of: %s\n" "${in_file}"
 


### PR DESCRIPTION
The issue that is resolved by this commit is that Github actions (through `action.yml`) gives the list of modified files in 1 single argument, instead of splitting it in multiple arguments.

Here is the run log with the current `master` in case a repo modifies several `.md` files:
```
/usr/bin/docker run --name a33c13d96f56f759642a3a055405b2c6c3c91_72e3d5 --label 8a33c1 --workdir /github/workspace --rm -e HIDE_CODEBLOCKS -e ABSOLUTE_IMAGE_LINKS -e OUTPUT_FILE_TYPE -e INPUT_FILES -e INPUT_OUTPUT -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/hybrid-platforms-conductor/hybrid-platforms-conductor":"/github/workspace" 8a33c1:3d96f56f759642a3a055405b2c6c3c91  "docs/mermaid_gen" "docs/executables.md docs/executables/check-node.md"
```

Here the issue is the last argument: it is the concatenation of the 2 modified files: `"docs/executables.md docs/executables/check-node.md"`.
However the `entrypoint.sh` script iterates through this list using `for in_file in "$@"; do` which will just have 1 iteration with `in_file` set to `docs/executables.md docs/executables/check-node.md`. Of course this doesn't work as there is no file by that name.

The fix proposed here is to consider the argument as an IFS-separated string. It solves the problem unless you are using file names having spaces of course.

To both support multiple files and file names having spaces, it is needed to find a way for `action.yml` to pass the second argument as a list.