### PR TITLE
Support extra arguments to mmdc through the MMDC_EXTRA_ARGS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ Looking for suggestions/help in improving this action. If there is a feature you
 ## How to use
 
 The idea is that this action is to be used within a workflow, not as a standalone action at this time.
-OUTPUT_FILE_TYPE can be used to define the output file type, if you don't specify it it will default to png. You can override it to svg or pdf.
+
+Some environment variables can be set to tune the compilation:
+* `OUTPUT_FILE_TYPE` can be used to define the output file type, if you don't specify it it will default to png. You can override it to svg or pdf.
+* `MMDC_EXTRA_ARGS` can be used to add extra command line arguments to the `mmdc` command line generating diagrams. Do not include `-i`, `-o` and `-p` arguments as they are already handled outside of this variable.
 
 ### Sample workflow with automated PR
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,9 @@
 
 set -euo pipefail
 
+# Normalize some environment variables (default values)
+MMDC_EXTRA_ARGS="${MMDC_EXTRA_ARGS:-}"
+
 function main {
   printf "Using MMDC version %s\n" "$(/node_modules/.bin/mmdc -V)"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,7 +77,8 @@ function is_path_markdown {
 function c_mermaid {
   printf "Compiling: %s\n" "${1}"
   printf "Output to: %s\n" "${2}"
-  /node_modules/.bin/mmdc -p /mmdc/puppeteer-config.json -i "${1}" -o "${2}"
+  printf "Extra args: %s\n" "${MMDC_EXTRA_ARGS}"
+  /node_modules/.bin/mmdc -p /mmdc/puppeteer-config.json -i "${1}" -o "${2}" ${MMDC_EXTRA_ARGS}
   confirm_creation "${2}"
 }
 


### PR DESCRIPTION
This is especially useful to set width and height of generated diagrams, as it can't be set through Mermaid configuration.